### PR TITLE
feat: allow Claude Code to run Go commands in GitHub Actions

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -69,7 +69,7 @@ jobs:
           #   'Please provide a thorough code review focusing on our coding standards and best practices.' }}
           
           # Optional: Add specific tools for running tests or linting
-          # allowed_tools: "Bash(npm run test),Bash(npm run lint),Bash(npm run typecheck)"
+          allowed_tools: "Bash(go test:*),Bash(go get:*),Bash(go run:*),Bash(go build:*),Bash(go mod:*),Bash(go list:*),Bash(go fmt:*),Bash(go vet:*),Bash(go doc:*),Bash(make:*)"
           
           # Optional: Skip review for certain conditions
           # if: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -50,7 +50,7 @@ jobs:
           # assignee_trigger: "claude-bot"
           
           # Optional: Allow Claude to run specific commands
-          # allowed_tools: "Bash(npm install),Bash(npm run build),Bash(npm run test:*),Bash(npm run lint:*)"
+          allowed_tools: "Bash(go test:*),Bash(go get:*),Bash(go run:*),Bash(go build:*),Bash(go mod:*),Bash(go list:*),Bash(go fmt:*),Bash(go vet:*),Bash(go doc:*),Bash(make:*)"
           
           # Optional: Add custom instructions for Claude to customize its behavior for your project
           # custom_instructions: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,6 +154,16 @@ for i := 0; i < resourceSpans.Len(); i++ {
 - **CI/CD integrations**: GitHub Actions, Jenkins plugins
 - **Community adoption**: OpenTelemetry community feedback and contributions
 
+## Claude Code GitHub Actions
+
+Claude Code is enabled for this repository with the following permissions:
+- **Go commands**: `go test`, `go get`, `go run`, `go build`, `go mod`, `go list`, `go fmt`, `go vet`, `go doc`
+- **Make commands**: All make targets
+
+These commands are available in both:
+- Interactive mode (via @claude mentions in issues/PRs)
+- Automated PR reviews
+
 ## Notes for Claude
 
 When working on this project:


### PR DESCRIPTION
## Summary
- Enable Go commands for Claude Code GitHub Actions
- Allow Claude to run typical Go developer commands
- Document the allowed commands in CLAUDE.md

## Changes
- Updated `.github/workflows/claude.yml` to allow Go commands (test, get, run, build, mod, list, fmt, vet, doc)
- Updated `.github/workflows/claude-code-review.yml` with the same Go command permissions
- Added documentation in `CLAUDE.md` about Claude Code GitHub Actions permissions
- Enabled all `make` targets for Claude Code

## Testing
The changes enable the following commands for Claude Code:
- `go test:*` - Run tests
- `go get:*` - Get dependencies
- `go run:*` - Run Go programs
- `go build:*` - Build Go programs
- `go mod:*` - Module management
- `go list:*` - List packages
- `go fmt:*` - Format code
- `go vet:*` - Vet code
- `go doc:*` - Documentation
- `make:*` - All make targets

Fixes #5